### PR TITLE
Added landingpage-URL and attachments-URLs as dc:identifier

### DIFF
--- a/src/main/java/de/qucosa/dc/disseminator/DcDisseminationServlet.java
+++ b/src/main/java/de/qucosa/dc/disseminator/DcDisseminationServlet.java
@@ -12,21 +12,35 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
 
+import javax.servlet.ServletConfig;
 import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.nio.charset.UnsupportedCharsetException;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
@@ -37,17 +51,45 @@ public class DcDisseminationServlet extends HttpServlet {
 
     private static final long serialVersionUID = 1L;
     private static final String REQUEST_PARAM_METS_URL = "metsurl";
+    private static final String PARAM_TRANSFER_URL_PIDENCODE = "transfer.url.pidencode";
+    private static final String PARAM_AGENT_NAME_SUBSTITUTIONS = "agent.substitutions";
 
     private CloseableHttpClient httpClient;
     private ObjectPool<Transformer> transformerPool;
+
+    private Map<String, String> agentNameSubstitutions;
+    private boolean transferUrlPidencode = false;
+
+    private XPathExpression XPATH_AGENT;
 
     @Override
     public void init() {
         warnIfDefaultEncodingIsNotUTF8();
 
+        XPath xPath = XPathFactory.newInstance().newXPath();
+        xPath.setNamespaceContext(new SimpleNamespaceContext(new HashMap<String, String>() {{
+            put("mets", "http://www.loc.gov/METS/");
+        }}));
+
+        try {
+            XPATH_AGENT = xPath.compile("//mets:agent[@ROLE='EDITOR' and @TYPE='ORGANIZATION']/mets:name[1]");
+        } catch (XPathExpressionException e) {
+            throw new IllegalStateException(e);
+        }
+
         httpClient = HttpClientBuilder.create()
                 .setConnectionManager(new PoolingHttpClientConnectionManager())
                 .build();
+
+        ServletConfig servletConfig = getServletConfig();
+
+        transferUrlPidencode = Boolean.valueOf(
+                getParameterValue(servletConfig, PARAM_TRANSFER_URL_PIDENCODE,
+                        System.getProperty(PARAM_TRANSFER_URL_PIDENCODE, "false")));
+
+        agentNameSubstitutions = decodeSubstitutions(
+                getParameterValue(servletConfig, PARAM_AGENT_NAME_SUBSTITUTIONS,
+                        System.getProperty(PARAM_AGENT_NAME_SUBSTITUTIONS, "")));
 
         transformerPool = new GenericObjectPool<>(new BasePooledObjectFactory<Transformer>() {
             @Override
@@ -96,17 +138,30 @@ public class DcDisseminationServlet extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+
         try {
             URI metsDocumentUri = URI.create(getRequiredRequestParameterValue(request, REQUEST_PARAM_METS_URL));
 
             try (CloseableHttpResponse resp = httpClient.execute(new HttpGet(metsDocumentUri))) {
-
                 if (SC_OK == resp.getStatusLine().getStatusCode()) {
-                    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+
+                    InputStream metsDocumentInputStream = resp.getEntity().getContent();
+
+                    DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+                    documentBuilderFactory.setNamespaceAware(true);
+                    Document metsDocument = documentBuilderFactory.newDocumentBuilder().parse(metsDocumentInputStream);
+
+                    String agentName = extractAgentName(metsDocument);
+                    String pid = extractObjectPID(metsDocument, transferUrlPidencode);
 
                     Transformer transformer = transformerPool.borrowObject();
+
+                    transformer.setParameter("agent", agentName);
+                    transformer.setParameter("qpid", pid);
+
+                    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
                     transformer.transform(
-                            new StreamSource(resp.getEntity().getContent()),
+                            new DOMSource(metsDocument),
                             new StreamResult(byteArrayOutputStream)
                     );
                     transformerPool.returnObject(transformer);
@@ -144,5 +199,47 @@ public class DcDisseminationServlet extends HttpServlet {
         }
 
         return value;
+    }
+
+    private String extractAgentName(Document metsDocument) throws XPathExpressionException {
+        String agentNameElement = XPATH_AGENT.evaluate(metsDocument);
+        if (agentNameElement != null) {
+            String agentName = agentNameElement.trim();
+            if (agentNameSubstitutions.containsKey(agentName)) {
+                return agentNameSubstitutions.get(agentName);
+            } else {
+                return agentName;
+            }
+        }
+        return null;
+    }
+
+    private String extractObjectPID(Document metsDocument, boolean encodePid) {
+        String pid = metsDocument.getDocumentElement().getAttribute("OBJID");
+        if (pid != null && !pid.isEmpty() && encodePid) {
+            try {
+                pid = URLEncoder.encode(pid, "UTF-8");
+            } catch (UnsupportedEncodingException e) {
+                // UTF-8 is always supported, unless the JVM runtime changes this
+                throw new RuntimeException(e);
+            }
+        }
+        return pid;
+    }
+
+    private Map<String, String> decodeSubstitutions(String parameterValue) {
+        LinkedHashMap<String, String> result = new LinkedHashMap<>();
+        if (parameterValue != null && !parameterValue.isEmpty()) {
+            for (String substitution : parameterValue.split(";")) {
+                String[] s = substitution.split("=");
+                result.put(s[0].trim(), s[1].trim());
+            }
+        }
+        return result;
+    }
+
+    private String getParameterValue(ServletConfig config, String name, String defaultValue) {
+        String v = config.getServletContext().getInitParameter(name);
+        return v == null ? defaultValue : v;
     }
 }

--- a/src/main/java/de/qucosa/dc/disseminator/SimpleNamespaceContext.java
+++ b/src/main/java/de/qucosa/dc/disseminator/SimpleNamespaceContext.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2017 Saxon State and University Library Dresden (SLUB)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.qucosa.dc.disseminator;
+
+import javax.xml.namespace.NamespaceContext;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+public class SimpleNamespaceContext implements NamespaceContext {
+
+    private final Map<String, String> PREF_MAP = new HashMap<>();
+
+    SimpleNamespaceContext(final Map<String, String> prefMap) {
+        PREF_MAP.putAll(prefMap);
+    }
+
+    public String getNamespaceURI(String prefix) {
+        return PREF_MAP.get(prefix);
+    }
+
+    public String getPrefix(String uri) {
+        throw new UnsupportedOperationException();
+    }
+
+    public Iterator getPrefixes(String uri) {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/src/main/resources/mets2dcdata.xsl
+++ b/src/main/resources/mets2dcdata.xsl
@@ -20,11 +20,16 @@
     <variable name="documentType" select="/mets:mets/mets:structMap[@TYPE='LOGICAL']/mets:div/@TYPE" />
     <variable name="documentStatus" select="//mods:originInfo[@eventType='production']/mods:edition[1]" />
 
+    <!-- URL parameter for substitutions (dc:identifier): frontpage-URL and transfer-URLs, passed from dissemination servlet -->
+    <param name="qpid"/>
+    <param name="agent"/>
+
     <template match="/mets:mets">
         <oai_dc:dc>
             <apply-templates select="mets:dmdSec[@ID='DMD_000']/mets:mdWrap[@MDTYPE='MODS']/mets:xmlData/mods:mods"/>
             <apply-templates select="mets:amdSec/mets:techMD/mets:mdWrap/mets:xmlData/slub:info"/>
             <apply-templates select="mets:structMap/mets:div"/>
+            <apply-templates select="mets:fileSec"/>
         </oai_dc:dc>
     </template>
 
@@ -99,12 +104,29 @@
                 </otherwise>
             </choose>
         </dc:type>
+
+        <if test="$agent and $qpid">
+            <dc:identifier>
+                <value-of select="replace(replace('http://##AGENT##.qucosa.de/id/##PID##', '##AGENT##', $agent), '##PID##', $qpid)" />
+            </dc:identifier>
+        </if>
     </template>
+
 
     <template match="mods:identifier">
         <dc:identifier>
             <value-of select="."/>
         </dc:identifier>
+    </template>
+
+    <template match="mets:fileSec">
+        <for-each select="mets:fileGrp[@USE='DOWNLOAD']/*">
+            <if test="$agent and $qpid">
+                <dc:identifier>
+                    <value-of select="replace(replace(replace('http://##AGENT##.qucosa.de/api/##PID##/attachment/##ATT##', '##AGENT##', $agent), '##PID##', $qpid), '##ATT##', ./@ID)" />
+                </dc:identifier>
+            </if>
+        </for-each>
     </template>
 
     <template match="mods:language/mods:languageTerm[matches(@authority, '^iso639-[1|2]')]">

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -20,6 +20,24 @@
          xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
 		  http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" version="2.5">
 
+    <!--
+        If `true` the objects PID gets URL encoded when constructing the transfer URL.
+    -->
+    <context-param>
+        <param-name>transfer.url.pidencode</param-name>
+        <param-value>true</param-value>
+    </context-param>
+
+    <!--
+        Context parameter defining whether the value of ##AGENT## should be mapped to something else
+        in the process of forming the transfer URL.
+    -->
+    <context-param>
+        <param-name>agent.substitutions</param-name>
+        <param-value>ubc=monarch ; ubl=ul</param-value>
+    </context-param>
+
+
     <servlet>
         <servlet-name>DcDisseminationServlet</servlet-name>
         <servlet-class>de.qucosa.dc.disseminator.DcDisseminationServlet</servlet-class>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -32,11 +32,12 @@
         Context parameter defining whether the value of ##AGENT## should be mapped to something else
         in the process of forming the transfer URL.
     -->
+<!--
     <context-param>
         <param-name>agent.substitutions</param-name>
         <param-value>ubc=monarch ; ubl=ul</param-value>
     </context-param>
-
+-->
 
     <servlet>
         <servlet-name>DcDisseminationServlet</servlet-name>


### PR DESCRIPTION
Added landingpage-URL as dc:identifier (OpenAire).
Added Attachments-URLs as dc:identifier (Core). Takes the first three
attachments (not restricted by MIMETYPE).
Resolves https://jira.slub-dresden.de/browse/CMR-397