### PR TITLE
Fix: Comma seperated ddc groups are divided into multiple dc:subject fields

### DIFF
--- a/src/main/resources/mets2dcdata.xsl
+++ b/src/main/resources/mets2dcdata.xsl
@@ -220,12 +220,42 @@
     </template>
 
     <template match="mods:classification[@authority='ddc']">
-        <dc:subject>
-            <value-of select="concat('info:eu-repo/classification/ddc/', .)"/>
-        </dc:subject>
-        <dc:subject>
-            <value-of select="concat('ddc:', .)"/>
-        </dc:subject>
+        <call-template name="mapSubjectListDc">
+            <with-param name="subjects">
+                <value-of select="."/>
+            </with-param>
+        </call-template>
+    </template>
+
+    <template name="mapSubjectListDc">
+        <param name="subjects"/>
+        <choose>
+            <when test="contains($subjects, ',')">
+                <variable name="head" select="normalize-space(substring-before($subjects, ','))"/>
+                <variable name="tail" select="normalize-space(substring-after($subjects, ','))"/>
+                <element name="dc:subject">
+                    <value-of select="concat('info:eu-repo/classification/ddc/', $head)"/>
+                </element>
+                <element name="dc:subject">
+                    <value-of select="concat('ddc:', $head)"/>
+                </element>
+                <if test="string-length($tail) > 0">
+                    <call-template name="mapSubjectListDc">
+                        <with-param name="subjects">
+                            <value-of select="$tail"/>
+                        </with-param>
+                    </call-template>
+                </if>
+            </when>
+            <otherwise>
+                <element name="dc:subject">
+                    <value-of select="concat('info:eu-repo/classification/ddc/', $subjects)"/>
+                </element>
+                <element name="dc:subject">
+                    <value-of select="concat('ddc:', $subjects)"/>
+                </element>
+            </otherwise>
+        </choose>
     </template>
 
     <template match="mods:classification[@authority='z']">


### PR DESCRIPTION
In addition to https://jira.slub-dresden.de/browse/CMR-473